### PR TITLE
Added post information to feedback email

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -150,13 +150,18 @@ add_action('wp_ajax_nopriv_tsml_feedback', 'tsml_feedback');
 function tsml_feedback() {
 	global $tsml_feedback_addresses, $tsml_nonce;
 	
+    $address = sanitize_text_field($_POST['tsml_address']);
+    $city    = sanitize_text_field($_POST['tsml_city']);
+    $state   = sanitize_text_field($_POST['tsml_state']);
+    $postal   = sanitize_text_field($_POST['tsml_postal_code']);
+    $name    = sanitize_text_field($_POST['tsml_name']);
+    $email  = sanitize_email($_POST['tsml_email']);
+    $message  = stripslashes(implode('<br>', array_map('sanitize_text_field', explode("\n", $_POST['tsml_message']))));
+
+    //append footer to message
+    $message .= '<br><br>Address: '.$address.'<br>City: '.$city.'<br>State: '.$state.'<br>Postal Code: '.$postal.'<br><br><hr>Edit meeting: <a href="' . $_POST['tsml_url'] . '">' . $_POST['tsml_url'] . '</a>';
+
 	//sanitize input
-	$name	 = sanitize_text_field($_POST['tsml_name']);
-	$email	= sanitize_email($_POST['tsml_email']);
-	$message  = stripslashes(implode('<br>', array_map('sanitize_text_field', explode("\n", $_POST['tsml_message']))));
-	
-	//append footer to message
-	$message .= '<br><br><hr>Edit meeting: <a href="' . $_POST['tsml_url'] . '">' . $_POST['tsml_url'] . '</a>';
 	
 	//email vars
 	$subject  = '[12 Step Meeting List] Meeting Feedback Form';

--- a/templates/single-meetings.php
+++ b/templates/single-meetings.php
@@ -73,6 +73,10 @@ $meeting = tsml_get_meeting();
 							
 							<form>
 								<input type="hidden" name="action" value="tsml_feedback">
+								<input type="hidden" name="tsml_address" value="<?php echo $meeting->address;?>">
+								<input type="hidden" name="tsml_city" value="<?php echo $meeting->city;?>">
+								<input type="hidden" name="tsml_state" value="<?php echo $meeting->state;?>">
+								<input type="hidden" name="tsml_postal_code" value="<?php echo $meeting->postal_code;?>">
 								<input type="hidden" name="tsml_url" value="<?php echo admin_url('post.php?post=' . get_the_ID() . '&action=edit')?>">
 								<?php wp_nonce_field($tsml_nonce, 'tsml_nonce', false)?>
 								<div class="form-group">


### PR DESCRIPTION
I added address, city, state, zip to the feedback email.  This is because the url that is placed at the bottom of the email refers to a post id which changes for us nightly as we re-import meetings from our source database.